### PR TITLE
Focus on input field after creating a new todo

### DIFF
--- a/src/TodoList.tsx
+++ b/src/TodoList.tsx
@@ -1,6 +1,6 @@
 // TODO: Refactor this component
 
-import { SetStateAction, useReducer, useState } from 'react';
+import { SetStateAction, useReducer, useRef, useState } from 'react';
 import { TodoItemType } from './App';
 
 type Props = {
@@ -138,6 +138,8 @@ export function TodoList(props: Props) {
   const [inputText, setInputText] = useState('');
   const [IsButtonDisabled, setIsButtonDisabled] = useState(true);
 
+  const inputRef = useRef<HTMLInputElement>(null);
+
   const toggleButtonState = (event: {
     currentTarget: { value: SetStateAction<string> };
   }) => {
@@ -159,6 +161,7 @@ export function TodoList(props: Props) {
   const addNewTodo = () => {
     dispatch(add(inputText));
     setInputText('');
+    inputRef.current?.focus();
   };
 
   const optionsOnSelect = [
@@ -193,6 +196,7 @@ export function TodoList(props: Props) {
       <input
         type="text"
         value={inputText}
+        ref={inputRef}
         onChange={toggleButtonState}
         onKeyDown={handleKeyDown}
       ></input>


### PR DESCRIPTION
https://speakerdeck.com/recruitengineers/react-yan-xiu-2024?slide=164

This pull request includes improvements to the `TodoList` component in `src/TodoList.tsx` to enhance user experience by managing focus on the input field. The most important changes include adding a `useRef` hook to handle input focus and modifying the `addNewTodo` function to focus on the input field after adding a new todo item.

Enhancements to input focus management:

* [`src/TodoList.tsx`](diffhunk://#diff-7a33d4ebc23311c83d6b82a19168d0ec379cc04a3249c49956e9a8f06ddf22fbL3-R3): Added `useRef` hook to manage the input field reference.
* [`src/TodoList.tsx`](diffhunk://#diff-7a33d4ebc23311c83d6b82a19168d0ec379cc04a3249c49956e9a8f06ddf22fbR141-R142): Declared `inputRef` using `useRef` to store the input field reference.
* [`src/TodoList.tsx`](diffhunk://#diff-7a33d4ebc23311c83d6b82a19168d0ec379cc04a3249c49956e9a8f06ddf22fbR164): Modified `addNewTodo` function to focus on the input field after adding a new todo item.
* [`src/TodoList.tsx`](diffhunk://#diff-7a33d4ebc23311c83d6b82a19168d0ec379cc04a3249c49956e9a8f06ddf22fbR199): Added `ref={inputRef}` to the input element to link it with the `inputRef`.

