### PR TITLE
5-2 Clockアプリ

### DIFF
--- a/src/Clock.tsx
+++ b/src/Clock.tsx
@@ -10,28 +10,37 @@ const hourCycles: HourCycle[] = [
 ];
 
 export function Clock() {
-  const [selected, setSelected] = useState('h12');
+  const [selected, setSelected] = useState<'h12' | 'h24'>('h12');
 
-  const isHour12 = () => selected === 'h12';
-  const formatOptions = { hour: '2-digit' as const, minute: '2-digit' as const, second: '2-digit' as const, hour12: isHour12() };
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  const formatOptions = {
+    hour: '2-digit' as const,
+    minute: '2-digit' as const,
+    second: '2-digit' as const,
+    hour12: selected === 'h12',
+  }
 
-  const [time, setTime] = useState(new Date().toLocaleTimeString([], formatOptions));
+  const [time, setTime] = useState(
+    new Date().toLocaleTimeString([], formatOptions)
+  );
 
   const handleChange: React.ChangeEventHandler<HTMLInputElement> = (event) => {
-    setSelected(event.currentTarget.value);
-  }
+    setSelected(event.currentTarget.value as 'h12' | 'h24');
+  };
 
   useEffect(() => {
     const controller = new AbortController();
     const signal = controller.signal;
-    setTimeout(() => {
-      setTime(
-        new Date().toLocaleTimeString([], formatOptions)
-      );
-    }, 1000, signal);
+    setTimeout(
+      () => {
+        setTime(new Date().toLocaleTimeString([], formatOptions));
+      },
+      1000,
+      signal
+    );
 
     return () => controller.abort();
-  });
+  }, [formatOptions]);
 
   return (
     <div>
@@ -49,5 +58,5 @@ export function Clock() {
         </label>
       ))}
     </div>
-  )
+  );
 }

--- a/src/Clock.tsx
+++ b/src/Clock.tsx
@@ -25,7 +25,10 @@ export function Clock() {
   );
 
   const handleChange: React.ChangeEventHandler<HTMLInputElement> = (event) => {
-    setSelected(event.currentTarget.value as 'h12' | 'h24');
+    const value = event.currentTarget.value;
+    if (value === 'h12' || value === 'h24') {
+      setSelected(value);
+    }
   };
 
   useEffect(() => {


### PR DESCRIPTION
- **Add dependency to useEffect()**
- **Directly check if value is 'h12' or 'h24'**

This pull request includes changes to the `Clock` component in `src/Clock.tsx` to improve type safety and ensure proper handling of state updates and side effects. The most important changes include refining the state type, updating the `formatOptions` object, and enhancing the `handleChange` function.

### Type Safety and State Management:

* [`src/Clock.tsx`](diffhunk://#diff-f2f9e767fc6c1415b1fb73d5de304a88a51fac71da0039a9472cf2fdda83ed6eL13-R46): Updated the `useState` hook to use a more specific type for `selected` state (`'h12' | 'h24'`).

### Code Simplification and Bug Fixes:

* [`src/Clock.tsx`](diffhunk://#diff-f2f9e767fc6c1415b1fb73d5de304a88a51fac71da0039a9472cf2fdda83ed6eL13-R46): Refactored the `formatOptions` object to directly use the `selected` state, removing the `isHour12` function.
* [`src/Clock.tsx`](diffhunk://#diff-f2f9e767fc6c1415b1fb73d5de304a88a51fac71da0039a9472cf2fdda83ed6eL13-R46): Enhanced the `handleChange` function to include a type guard, ensuring only valid values are set to `selected`.
* [`src/Clock.tsx`](diffhunk://#diff-f2f9e767fc6c1415b1fb73d5de304a88a51fac71da0039a9472cf2fdda83ed6eL13-R46): Adjusted the `useEffect` dependency array to include `formatOptions` and fixed the `setTimeout` usage.

### Code Style:

* [`src/Clock.tsx`](diffhunk://#diff-f2f9e767fc6c1415b1fb73d5de304a88a51fac71da0039a9472cf2fdda83ed6eL52-R64): Added a missing semicolon at the end of the `return` statement in the `Clock` component.