### PR TITLE
5-3 Clockアプリ

### DIFF
--- a/src/Clock.tsx
+++ b/src/Clock.tsx
@@ -10,6 +10,7 @@ const hourCycles: HourCycle[] = [
 ];
 
 export function Clock() {
+  console.log('Clock rendered');
   const [selected, setSelected] = useState<'h12' | 'h24'>('h12');
 
   // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -32,11 +33,15 @@ export function Clock() {
   };
 
   useEffect(() => {
+    console.log('Clock effect');
     const intervalId = setInterval(() => {
       setTime(new Date().toLocaleTimeString([], formatOptions));
     }, 1000);
 
-    return () => clearInterval(intervalId);
+    return () => {
+      console.log('Clock cleanup');
+      clearInterval(intervalId);
+    }
   }, [formatOptions]);
 
   return (

--- a/src/Clock.tsx
+++ b/src/Clock.tsx
@@ -18,7 +18,7 @@ export function Clock() {
     minute: '2-digit' as const,
     second: '2-digit' as const,
     hour12: selected === 'h12',
-  }
+  };
 
   const [time, setTime] = useState(
     new Date().toLocaleTimeString([], formatOptions)
@@ -32,17 +32,11 @@ export function Clock() {
   };
 
   useEffect(() => {
-    const controller = new AbortController();
-    const signal = controller.signal;
-    setTimeout(
-      () => {
-        setTime(new Date().toLocaleTimeString([], formatOptions));
-      },
-      1000,
-      signal
-    );
+    const intervalId = setInterval(() => {
+      setTime(new Date().toLocaleTimeString([], formatOptions));
+    }, 1000);
 
-    return () => controller.abort();
+    return () => clearInterval(intervalId);
   }, [formatOptions]);
 
   return (


### PR DESCRIPTION
- **Use setInterval() instead of setTimeout()**
- **Add console.log to see the lifecycle on Strict Mode**

This pull request includes several changes to the `Clock` component in the `src/Clock.tsx` file. The changes primarily involve adding console logs for debugging purposes and modifying the interval handling logic.

### Debugging and Logging:

* Added a `console.log` statement to log when the `Clock` component is rendered. (`src/Clock.tsx`)
* Added a `console.log` statement within the `useEffect` hook to log when the effect runs. (`src/Clock.tsx`)
* Added a `console.log` statement to log when the cleanup function in the `useEffect` hook is called. (`src/Clock.tsx`)

### Interval Handling:

* Replaced the `setTimeout` logic with `setInterval` for updating the time every second. (`src/Clock.tsx`)
* Removed the use of `AbortController` and its signal for managing the timeout, simplifying the cleanup logic to use `clearInterval`. (`src/Clock.tsx`)

### Code Formatting:

* Fixed a minor formatting issue by adding a semicolon after the `formatOptions` object. (`src/Clock.tsx`)