### PR TITLE
Fix Property 'toBeInTheDocument' does not exist on type 'Assertion<HTMLElement>'.

### DIFF
--- a/src/setupTests.ts
+++ b/src/setupTests.ts
@@ -1,1 +1,1 @@
-import '@testing-library/jest-dom/vitest';
+import '@testing-library/jest-dom';


### PR DESCRIPTION
toBeInTheDocument is a method of @testing-library/jest-dom library and needs to be added.

This pull request includes a small change to the `src/setupTests.ts` file. The change updates the import statement for `@testing-library/jest-dom` by removing the `vitest` suffix.

* [`src/setupTests.ts`](diffhunk://#diff-84f6be72ed45f1bf4cdbd441d0bd824e38270a7599bd4eac2981b05eb7ad9d29L1-R1): Updated the import statement to use `@testing-library/jest-dom` without the `vitest` suffix.